### PR TITLE
Bugfix: rogue ellipses

### DIFF
--- a/src/staxchg/string.clj
+++ b/src/staxchg/string.clj
@@ -3,13 +3,13 @@
   (:gen-class))
 
 (defn truncate
-  "If word is longer than width, excess characters plus one are replaced by a
-   single ellipsis (…) character."
-  [word width]
-  (let [length (count word)]
+  "If string is longer than width, excess characters plus one are replaced by a
+   single ellipses (…) character."
+  [string width]
+  (let [length (count string)]
     (if (<= length width)
-      word
-      (str (subs word 0 (max 0 (dec width))) \…))))
+      string
+      (str (subs string 0 (max 0 (dec width))) \…))))
 
 (defn bite
   "Breaks off the beginning of string such that it is:

--- a/src/staxchg/string.clj
+++ b/src/staxchg/string.clj
@@ -11,9 +11,29 @@
       word
       (str (subs word 0 (max 0 (dec width))) \…))))
 
-(def truncated?
-  "True if a word has been truncated, false otherwise."
-  (comp #{\…} last))
+(defn bite
+  "Breaks off the beginning of string such that it is:
+     * width characters at most
+     * either followed by a space or no longer than width
+   Should the above be impossible, policy comes into effect:
+     * :truncate   fragment is (width - 1) characters followed by an
+                   ellipses character (…)
+     * :float      fragment is an empty string
+   The fragment and the remainder are returned in a vector. The space character
+   following the fragment is not included in the remainder."
+  [width string policy]
+  (when-not (contains? #{:truncate :float} policy)
+    (throw (IllegalArgumentException. (str "Unsupported policy: " policy))))
+  (loop [string string
+         result nil]
+    (let [[head tail] (string/split string #" " 2)
+          joined (->> [result head] (remove nil?) (string/join " "))
+          fits? (<= (count joined) width)]
+      (cond (and fits? tail)        (recur tail joined)
+            (and fits? (nil? tail)) [joined]
+            (not-empty result)      [result string]
+            (= :truncate policy)    [(truncate head width) tail]
+            (= :float policy)       ["" string]))))
 
 (defn pack
   "Splits string into a vector of strings, none of which is longer than width.
@@ -23,34 +43,21 @@
      * if no split yields parts of appropriate length, string is truncated
 
    When provided, x denotes an indentation applicable to the first line only."
-  ([width string]
-   (if (->> string count (>= width))
-     [string]
-     (reduce
-       (fn [aggregator word]
-         (let [previous (peek aggregator)
-               popped (if-not (empty? aggregator) (pop aggregator) aggregator)]
-           (if (<= (+ (count previous) (count word) 1) width)
-             (conj popped (string/join \space (remove nil? [previous word])))
-             (conj aggregator (truncate word width)))))
-       []
-       (string/split string #"(?<!^\s*)\s(?!\s|$)"))))
-  ([x width string]
-   (loop [string string
-          result []
-          index 0]
-     (let [top? (zero? index)
-           packed (-> (cond-> width
-                        top? (- x))
-                      (pack string))
-           packed (if (and top? (truncated? (first packed)))
-                    ["" (string/triml string)]
-                    packed)]
-       (if (= (count packed) 1)
-         (vec (concat result packed))
-         (recur (->> packed rest (remove string/blank?) (string/join \space))
-                (conj result (first packed))
-                (inc index)))))))
+  [x width string]
+  (loop [string string
+         result []
+         index 0]
+    (let [top? (zero? index)
+          [bit remainder] (bite (cond-> width
+                                  top? (- x))
+                                string
+                                (if top? :float :truncate))
+          result (conj result bit)]
+      (if (nil? remainder)
+        result
+        (recur remainder
+               result
+               (inc index))))))
 
 (defn reflow
   "Introduces line breaks into string so that no line is longer than width. The

--- a/test/staxchg/string_test.clj
+++ b/test/staxchg/string_test.clj
@@ -2,38 +2,59 @@
   (:require [clojure.test :refer :all]
             [staxchg.string :refer :all]))
 
-(deftest pack-test
+(deftest bite-test
   (testing "ready fit"
-    (is (= (pack 3 "abc") ["abc"])))
+    (testing "one word"
+      (are [policy] (= (bite 3 "abc" policy) ["abc"])
+           :truncate
+           :float))
+    (testing "multiple words"
+      (are [policy] (= (bite 11 "abc 123 xyz" policy) ["abc 123 xyz"])
+           :truncate
+           :float)))
   (testing "break"
-    (is (= (pack 5 "abc xyz") ["abc" "xyz"])))
+    (are [policy] (= (bite 5 "abc xyz" policy) ["abc" "xyz"])
+         :truncate
+         :float))
   (testing "preserves whitespace before break"
-    (are [width string split] (= (pack width string) split)
+    (are [width string split] (= (bite width string :float) split)
          4 "abc xyz"   ["abc"   "xyz"]
          5 "abc  xyz"  ["abc "  "xyz"]
          6 "abc   xyz" ["abc  " "xyz"]))
   (testing "preserves trailing whitespace"
-    (are [width string split] (= (pack width string) split)
+    (are [width string split] (= (bite width string :float) split)
          3 "abc xyz"   ["abc" "xyz"  ]
          4 "abc xyz "  ["abc" "xyz " ]
          5 "abc xyz  " ["abc" "xyz  "]))
-  (testing "truncation"
-    (is (= (pack 3 "abcd") ["ab…"])))
-  (testing "x"
-    (testing "minimal"
-      (is (= (pack 1 7 "abc xyz") ["abc" "xyz"])))
-    (testing "x affects first line only"
-      (is (= (pack 1 7 "abc xyz klm") ["abc" "xyz klm"])))
-    (testing "x: truncation (word fits below)"
-      (is (= (pack 1 4 "abcd") ["" "abcd"])))
-    (testing "x: truncation (word doesn't fit below)"
-      (is (= (pack 1 3 "abcd") ["" "ab…"])))
-    (testing "x equal to width"
-      (is (= (pack 3 3 "abc") ["" "abc"])))
-    (testing "x greater than width"
-      (is (= (pack 4 3 "abc") ["" "abc"])))
-    (testing "x: trim left"
-      (is (= (pack 7 7 " abc def") ["" "abc def"])))))
+  (testing "no fit"
+    (testing "with truncation"
+      (is (= (bite 3 "abcd" :truncate) ["ab…" nil])))
+    (testing "without truncation"
+      (is (= (bite 3 "abcd" :float) ["" "abcd"])))))
+
+(deftest pack-test
+  (testing "minimal"
+    (is (= (pack 1 7 "abc xyz") ["abc" "xyz"])))
+  (testing "x affects first line only"
+    (is (= (pack 1 7 "abc xyz klm") ["abc" "xyz klm"])))
+  (testing "truncation (word fits below)"
+    (is (= (pack 1 4 "abcd") ["" "abcd"])))
+  (testing "truncation (word doesn't fit below)"
+    (is (= (pack 1 3 "abcd") ["" "ab…"])))
+  (testing "x equal to width"
+    (is (= (pack 3 3 "abc") ["" "abc"])))
+  (testing "x greater than width"
+    (is (= (pack 4 3 "abc") ["" "abc"])))
+  (testing "trim left"
+    (is (= (pack 7 7 " abc def") ["" "abc def"])))
+  (testing "multiple lines"
+    (testing "no truncation"
+      (is (= (pack 7 10 "abc 1234 xyz 5678 def 90123456 qxy")
+             ["abc" "1234 xyz" "5678 def" "90123456" "qxy"])))
+    (testing "truncation"
+      (is (= (pack 7 10 "abc 1234 xyz 567890ABCDEF") ["abc" "1234 xyz" "567890ABC…"]))))
+  (testing "leading spaces"
+    (is (= (pack 0 100 "  return x;") ["  return x;"]))))
 
 (deftest trim-leading-indent-test
   (testing "pun nil"

--- a/test/staxchg/string_test.clj
+++ b/test/staxchg/string_test.clj
@@ -20,19 +20,20 @@
   (testing "truncation"
     (is (= (pack 3 "abcd") ["ab…"])))
   (testing "x"
-    (is (= (pack 1 7 "abc xyz") ["abc" "xyz"])))
-  (testing "x affects first line only"
-    (is (= (pack 1 7 "abc xyz klm") ["abc" "xyz klm"])))
-  (testing "x: truncation (word fits below)"
-    (is (= (pack 1 4 "abcd") ["" "abcd"])))
-  (testing "x: truncation (word doesn't fit below)"
-    (is (= (pack 1 3 "abcd") ["" "ab…"])))
-  (testing "x equal to width"
-    (is (= (pack 3 3 "abc") ["" "abc"])))
-  (testing "x greater than width"
-    (is (= (pack 4 3 "abc") ["" "abc"])))
-  (testing "x: trim left"
-    (is (= (pack 7 7 " abc def") ["" "abc def"]))))
+    (testing "minimal"
+      (is (= (pack 1 7 "abc xyz") ["abc" "xyz"])))
+    (testing "x affects first line only"
+      (is (= (pack 1 7 "abc xyz klm") ["abc" "xyz klm"])))
+    (testing "x: truncation (word fits below)"
+      (is (= (pack 1 4 "abcd") ["" "abcd"])))
+    (testing "x: truncation (word doesn't fit below)"
+      (is (= (pack 1 3 "abcd") ["" "ab…"])))
+    (testing "x equal to width"
+      (is (= (pack 3 3 "abc") ["" "abc"])))
+    (testing "x greater than width"
+      (is (= (pack 4 3 "abc") ["" "abc"])))
+    (testing "x: trim left"
+      (is (= (pack 7 7 " abc def") ["" "abc def"])))))
 
 (deftest trim-leading-indent-test
   (testing "pun nil"


### PR DESCRIPTION
Unnecessary ellipses appear at the end of the first line of paragraph. This is due to implementation flaws in `staxchg.string/reflow`.